### PR TITLE
Decouple ColorPalette from Client

### DIFF
--- a/src/main/java/com/buglife/sdk/ActivityUtils.java
+++ b/src/main/java/com/buglife/sdk/ActivityUtils.java
@@ -36,12 +36,11 @@ final class ActivityUtils {
     static final String INTENT_KEY_BUG_CONTEXT = "INTENT_KEY_BUG_CONTEXT";
     static final String INTENT_KEY_ATTACHMENT = "INTENT_KEY_ATTACHMENT";
 
-    static void setStatusBarColor(Activity activity) {
+    static void setStatusBarColor(Activity activity, int color) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             return;
         }
 
-        int color = Buglife.getColorPalette().getColorPrimaryDark();
         Window window = activity.getWindow();
         window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
         window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
@@ -58,11 +57,10 @@ final class ActivityUtils {
         return true;
     }
 
-    static @NonNull Drawable getTintedDrawable(@NonNull Context context, @DrawableRes int id) {
-        int titleTextColor = Buglife.getColorPalette().getTextColorPrimary();
+    static @NonNull Drawable getTintedDrawable(@NonNull Context context, @DrawableRes int id, int color) {
         Drawable drawable = context.getResources().getDrawable(id);
         drawable = DrawableCompat.wrap(drawable);
-        DrawableCompat.setTint(drawable, titleTextColor);
+        DrawableCompat.setTint(drawable, color);
         return drawable;
     }
 

--- a/src/main/java/com/buglife/sdk/Buglife.java
+++ b/src/main/java/com/buglife/sdk/Buglife.java
@@ -181,10 +181,6 @@ public final class Buglife {
         getClient().onFinishReportFlow();
     }
 
-    static ColorPalette getColorPalette() {
-        return getClient().getColorPalette();
-    }
-
     private static void verifyDependencies() {
         try {
             Class<?> clazz = Class.forName("com.android.volley.toolbox.JsonObjectRequest");

--- a/src/main/java/com/buglife/sdk/Client.java
+++ b/src/main/java/com/buglife/sdk/Client.java
@@ -77,7 +77,6 @@ final class Client implements ForegroundDetector.OnForegroundListener {
     @NonNull private final AttributeMap mAttributes;
     @Nullable private ArrayList<InputField> mInputFields;
     private boolean mReportFlowVisible = false;
-    @NonNull private final ColorPalette mColorPallete;
     private final BugReporter reporter;
 
     Client(Application application, BugReporter reporter, @Nullable String apiKey, @Nullable String email) {
@@ -88,7 +87,6 @@ final class Client implements ForegroundDetector.OnForegroundListener {
         mQueuedAttachments = new ArrayList();
         mAttributes = new AttributeMap();
         mForegroundDetector = new ForegroundDetector(application, this);
-        mColorPallete = new ColorPalette.Builder(mAppContext).build();
 
         boolean hasPermissions = checkPermissions();
 
@@ -117,10 +115,6 @@ final class Client implements ForegroundDetector.OnForegroundListener {
 
     Context getApplicationContext() {
         return mAppContext;
-    }
-
-    ColorPalette getColorPalette() {
-        return mColorPallete;
     }
 
     void setListener(@Nullable BuglifeListener listener) {

--- a/src/main/java/com/buglife/sdk/ReportActivity.java
+++ b/src/main/java/com/buglife/sdk/ReportActivity.java
@@ -64,6 +64,7 @@ public class ReportActivity extends AppCompatActivity {
     private ListView mAttachmentListView;
     private @NonNull List<InputField> mInputFields;
     private @Nullable ProgressDialog mProgressDialog;
+    private @NonNull ColorPalette mColorPalette;
 
     public ReportActivity() {
     }
@@ -111,8 +112,9 @@ public class ReportActivity extends AppCompatActivity {
             inputFieldView.setValue(currentValue);
         }
 
-        int colorPrimary = Buglife.getColorPalette().getColorPrimary();
-        int titleTextColor = Buglife.getColorPalette().getTextColorPrimary();
+        mColorPalette = new ColorPalette.Builder(this).build();
+        int colorPrimary = mColorPalette.getColorPrimary();
+        int titleTextColor = mColorPalette.getTextColorPrimary();
         String titleTextColorHex = ColorPalette.getHexColor(titleTextColor);
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
@@ -121,7 +123,7 @@ public class ReportActivity extends AppCompatActivity {
         ActionBar actionBar = getSupportActionBar();
 
         if (actionBar != null) {
-            Drawable drawable = ActivityUtils.getTintedDrawable(this, android.R.drawable.ic_menu_close_clear_cancel);
+            Drawable drawable = ActivityUtils.getTintedDrawable(this, android.R.drawable.ic_menu_close_clear_cancel, mColorPalette.getTextColorPrimary());
 
             actionBar.setHomeAsUpIndicator(drawable);
             actionBar.setDisplayHomeAsUpEnabled(true);
@@ -129,7 +131,7 @@ public class ReportActivity extends AppCompatActivity {
             actionBar.setTitle(getString(R.string.report_a_bug));
         }
 
-        ActivityUtils.setStatusBarColor(this);
+        ActivityUtils.setStatusBarColor(this, mColorPalette.getColorPrimaryDark());
     }
 
     private @Nullable String getValueForInputField(@NonNull InputField inputField) {
@@ -146,7 +148,7 @@ public class ReportActivity extends AppCompatActivity {
     public boolean onCreateOptionsMenu(Menu menu) {
         MenuItem sendItem = menu.add(0, SEND_MENU_ITEM, Menu.NONE, R.string.send);
         sendItem.setShowAsAction(SHOW_AS_ACTION_ALWAYS);
-        Drawable drawable = ActivityUtils.getTintedDrawable(this, android.R.drawable.ic_menu_send);
+        Drawable drawable = ActivityUtils.getTintedDrawable(this, android.R.drawable.ic_menu_send, mColorPalette.getTextColorPrimary());
         sendItem.setIcon(drawable);
 
         return true;

--- a/src/main/java/com/buglife/sdk/ScreenshotAnnotatorActivity.java
+++ b/src/main/java/com/buglife/sdk/ScreenshotAnnotatorActivity.java
@@ -67,6 +67,7 @@ public class ScreenshotAnnotatorActivity extends AppCompatActivity {
     private ImageButton mLoupeTool;
     private ImageButton mBlurTool;
     private AnnotationView mAnnotationView;
+    private ColorPalette mColorPalette;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -82,9 +83,11 @@ public class ScreenshotAnnotatorActivity extends AppCompatActivity {
         Bitmap bitmap = mAttachment.getBitmap(this);
         mAnnotationView.setImage(bitmap);
 
+        mColorPalette = new ColorPalette.Builder(this).build();
+
         // Annotation tools
         mAnnotationToolbar = findViewById(R.id.annotation_toolbar);
-        mAnnotationToolbar.setBackgroundColor(Buglife.getColorPalette().getColorPrimary());
+        mAnnotationToolbar.setBackgroundColor(mColorPalette.getColorPrimary());
 
         mArrowTool = (ImageButton) findViewById(R.id.arrow_tool);
         mLoupeTool = (ImageButton) findViewById(R.id.loupe_tool);
@@ -120,8 +123,8 @@ public class ScreenshotAnnotatorActivity extends AppCompatActivity {
         ActionBar actionBar = getSupportActionBar();
 
         if (actionBar != null) {
-            int colorPrimary = Buglife.getColorPalette().getColorPrimary();
-            int titleTextColor = Buglife.getColorPalette().getTextColorPrimary();
+            int colorPrimary = mColorPalette.getColorPrimary();
+            int titleTextColor = mColorPalette.getTextColorPrimary();
             final @DrawableRes int homeAsUpIndicatorDrawableId;
             final @StringRes int titleStringId;
 
@@ -136,7 +139,7 @@ public class ScreenshotAnnotatorActivity extends AppCompatActivity {
                 titleStringId = R.string.screenshot_annotator_activity_label;
             }
 
-            Drawable homeAsUpIndicator = ActivityUtils.getTintedDrawable(this, homeAsUpIndicatorDrawableId);
+            Drawable homeAsUpIndicator = ActivityUtils.getTintedDrawable(this, homeAsUpIndicatorDrawableId, mColorPalette.getTextColorPrimary());
             CharSequence title = ActivityUtils.getTextWithColor(this, titleTextColor, titleStringId);
             actionBar.setDisplayHomeAsUpEnabled(true);
             actionBar.setHomeAsUpIndicator(homeAsUpIndicator);
@@ -144,7 +147,7 @@ public class ScreenshotAnnotatorActivity extends AppCompatActivity {
             actionBar.setTitle(title);
         }
 
-        ActivityUtils.setStatusBarColor(this);
+        ActivityUtils.setStatusBarColor(this, mColorPalette.getColorPrimaryDark());
     }
 
     @Override
@@ -152,7 +155,7 @@ public class ScreenshotAnnotatorActivity extends AppCompatActivity {
         if (isInitialScreenshotAnnotationActivity()) {
             MenuItem sendItem = menu.add(0, NEXT_MENU_ITEM, Menu.NONE, R.string.next);
             sendItem.setShowAsAction(SHOW_AS_ACTION_ALWAYS);
-            Drawable drawable = ActivityUtils.getTintedDrawable(this, R.drawable.ic_arrow_right);
+            Drawable drawable = ActivityUtils.getTintedDrawable(this, R.drawable.ic_arrow_right, mColorPalette.getTextColorPrimary());
             sendItem.setIcon(drawable);
             return true;
         } else {
@@ -272,6 +275,6 @@ public class ScreenshotAnnotatorActivity extends AppCompatActivity {
     }
 
     private int getToolColorFilter() {
-        return Buglife.getColorPalette().getColorAccent();
+        return mColorPalette.getColorAccent();
     }
 }

--- a/src/main/java/com/buglife/sdk/TextInputFieldView.java
+++ b/src/main/java/com/buglife/sdk/TextInputFieldView.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Method;
 final class TextInputFieldView extends InputFieldView {
     private TextInputLayout mTextInputLayout;
     private EditText mEditText;
+    private ColorPalette mColorPalette;
 
     TextInputFieldView(Context context) {
         super(context);
@@ -45,7 +46,9 @@ final class TextInputFieldView extends InputFieldView {
     private void init() {
         inflate(getContext(), R.layout.text_input_field_view, this);
         mTextInputLayout = (TextInputLayout) findViewById(R.id.input_layout);
-        mEditText = (EditText) findViewById(R.id.edit_text);setHintColor();
+        mEditText = (EditText) findViewById(R.id.edit_text);
+        mColorPalette = new ColorPalette.Builder(getContext()).build();
+        setHintColor();
     }
 
     @Override
@@ -87,7 +90,7 @@ final class TextInputFieldView extends InputFieldView {
     }
 
     private void setHintColor() {
-        @ColorInt int colorAccent = Buglife.getColorPalette().getColorAccent();
+        @ColorInt int colorAccent = mColorPalette.getColorAccent();
 
         try {
             Field field = mTextInputLayout.getClass().getDeclaredField("mFocusedTextColor");


### PR DESCRIPTION
This refactor decouples `ColorPalette` from `Client`. Instead of the `Client` initializing it, it is now initialized by views (Activity/Fragment) when needed. 

I think ideally the main responsibility of the `Client` is to manage interaction between the user and the library (think Controller in MVC) and this small change is a step in that direction.

Tested with demo app to ensure correct color adoption from internal Activities (i.e. ReportActivity, etc).