### PR TITLE
Api Identity

### DIFF
--- a/src/main/java/com/buglife/sdk/ApiIdentity.java
+++ b/src/main/java/com/buglife/sdk/ApiIdentity.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2017 Buglife, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.buglife.sdk;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+interface ApiIdentity extends Parcelable {
+    String getId();
+
+    class ApiKey implements ApiIdentity {
+        private final String mApiKey;
+
+        ApiKey(String apiKey) {
+            this.mApiKey = apiKey;
+        }
+
+        @Override public String getId() {
+            return mApiKey;
+        }
+
+        /* Parcelable */
+
+        @Override public int describeContents() {
+            return 0;
+        }
+
+        @Override public void writeToParcel(Parcel dest, int flags) {
+            dest.writeString(mApiKey);
+        }
+
+        ApiKey(Parcel in) {
+            mApiKey = in.readString();
+        }
+
+        public static final Creator<ApiKey> CREATOR = new Creator<ApiKey>() {
+            @Override public ApiKey createFromParcel(Parcel source) {
+                return new ApiKey(source);
+            }
+
+            @Override public ApiKey[] newArray(int size) {
+                return new ApiKey[size];
+            }
+        };
+    }
+
+    class EmailAddress implements ApiIdentity {
+        private final String mEmailAddress;
+
+        EmailAddress(String emailAddress) {
+            this.mEmailAddress = emailAddress;
+        }
+
+        @Override public String getId() {
+            return mEmailAddress;
+        }
+
+        /* Parcelable */
+
+        @Override public int describeContents() {
+            return 0;
+        }
+
+        @Override public void writeToParcel(Parcel dest, int flags) {
+            dest.writeString(mEmailAddress);
+        }
+
+        EmailAddress(Parcel in) {
+            mEmailAddress = in.readString();
+        }
+
+        public static final Creator<EmailAddress> CREATOR = new Creator<EmailAddress>() {
+            @Override public EmailAddress createFromParcel(Parcel source) {
+                return new EmailAddress(source);
+            }
+
+            @Override public EmailAddress[] newArray(int size) {
+                return new EmailAddress[size];
+            }
+        };
+    }
+}

--- a/src/main/java/com/buglife/sdk/Client.java
+++ b/src/main/java/com/buglife/sdk/Client.java
@@ -60,8 +60,7 @@ final class Client implements ForegroundDetector.OnForegroundListener, Invocatio
     private static final String DEFAULT_SCREENSHOT_ATTACHMENT_TYPE = Attachment.TYPE_PNG;
 
     @NonNull private final Context mAppContext;
-    @Nullable private final String mApiKey;
-    @Nullable private final String mEmail;
+    private final ApiIdentity mApiIdentity;
     @Nullable private BuglifeListener mListener;
     @NonNull private InvocationMethod mInvocationMethod;
     @Nullable private InvocationMethodManager mInvocationMethodManager;
@@ -74,11 +73,10 @@ final class Client implements ForegroundDetector.OnForegroundListener, Invocatio
     private boolean mReportFlowVisible = false;
     private final BugReporter reporter;
 
-    Client(Application application, BugReporter reporter, @Nullable String apiKey, @Nullable String email) {
+    Client(Application application, BugReporter reporter,  ApiIdentity apiIdentity) {
         mAppContext = application.getApplicationContext();
         this.reporter = reporter;
-        mApiKey = apiKey;
-        mEmail = email;
+        mApiIdentity = apiIdentity;
         mQueuedAttachments = new ArrayList();
         mAttributes = new AttributeMap();
         mForegroundDetector = new ForegroundDetector(application, this);
@@ -317,8 +315,7 @@ final class Client implements ForegroundDetector.OnForegroundListener, Invocatio
         BugContext.Builder builder = new BugContext.Builder(mAppContext)
                 .setUserEmail(mUserEmail)
                 .setUserIdentifier(mUserIdentifier)
-                .setApiKey(mApiKey)
-                .setApiEmail(mEmail);
+                .setApiIdentity(mApiIdentity);
 
         if (mListener != null) {
             mListener.onAttachmentRequest();
@@ -377,19 +374,17 @@ final class Client implements ForegroundDetector.OnForegroundListener, Invocatio
 
     static class Builder {
         private Application mApplication;
-        @Nullable private String mApiKey;
-        @Nullable private String mEmail;
 
         Builder(Application application) {
             mApplication = application;
         }
 
         Client buildWithApiKey(String apiKey) {
-            return new Client(mApplication, new BugReporterImpl(mApplication), apiKey, null);
+            return new Client(mApplication, new BugReporterImpl(mApplication), new ApiIdentity.ApiKey(apiKey));
         }
 
         Client buildWithEmail(String email) {
-            return new Client(mApplication, new BugReporterImpl(mApplication), null, email);
+            return new Client(mApplication, new BugReporterImpl(mApplication), new ApiIdentity.EmailAddress(email));
         }
     }
 

--- a/src/main/java/com/buglife/sdk/Client.java
+++ b/src/main/java/com/buglife/sdk/Client.java
@@ -60,7 +60,7 @@ final class Client implements ForegroundDetector.OnForegroundListener, Invocatio
     private static final String DEFAULT_SCREENSHOT_ATTACHMENT_TYPE = Attachment.TYPE_PNG;
 
     @NonNull private final Context mAppContext;
-    private final ApiIdentity mApiIdentity;
+    @NonNull private final ApiIdentity mApiIdentity;
     @Nullable private BuglifeListener mListener;
     @NonNull private InvocationMethod mInvocationMethod;
     @Nullable private InvocationMethodManager mInvocationMethodManager;
@@ -73,7 +73,7 @@ final class Client implements ForegroundDetector.OnForegroundListener, Invocatio
     private boolean mReportFlowVisible = false;
     private final BugReporter reporter;
 
-    Client(Application application, BugReporter reporter,  ApiIdentity apiIdentity) {
+    Client(Application application, BugReporter reporter, @NonNull ApiIdentity apiIdentity) {
         mAppContext = application.getApplicationContext();
         this.reporter = reporter;
         mApiIdentity = apiIdentity;

--- a/src/main/java/com/buglife/sdk/Report.java
+++ b/src/main/java/com/buglife/sdk/Report.java
@@ -121,10 +121,11 @@ public final class Report {
         params.put("report", reportParams);
         params.put("app", appParams);
 
-        if (sessionSnapshot.getApiKey() != null) {
-            params.put("api_key", sessionSnapshot.getApiKey());
-        } else if (sessionSnapshot.getApiEmail() != null) {
-            params.put("email", sessionSnapshot.getApiEmail());
+        ApiIdentity identity = mBugContext.getApiIdentity();
+        if (identity instanceof ApiIdentity.ApiKey) {
+            params.put("api_key", identity.getId());
+        } else if (identity instanceof ApiIdentity.EmailAddress) {
+            params.put("email", identity.getId());
         }
 
         return params;

--- a/src/main/java/com/buglife/sdk/reporting/SessionSnapshot.java
+++ b/src/main/java/com/buglife/sdk/reporting/SessionSnapshot.java
@@ -37,10 +37,8 @@ public class SessionSnapshot implements Parcelable {
     private final String mBundleName;
     @Nullable private final String mBundleShortVersion;
     @Nullable private final String mBundleVersion;
-    @Nullable private final String mApiKey;
-    @Nullable private final String mApiEmail;
 
-    public SessionSnapshot(Context context, String userEmail, String userIdentifier, @Nullable String apiKey, @Nullable String apiEmail) {
+    public SessionSnapshot(Context context, String userEmail, String userIdentifier) {
         mPlatform = "android";
         mSDKVersion = com.buglife.sdk.BuildConfig.VERSION_NAME;
         mSDKName = "Buglife Android";
@@ -66,9 +64,6 @@ public class SessionSnapshot implements Parcelable {
             mBundleVersion = null;
             mBundleShortVersion = null;
         }
-
-        mApiKey = apiKey;
-        mApiEmail = apiEmail;
     }
 
     public String getPlatform() {
@@ -109,14 +104,6 @@ public class SessionSnapshot implements Parcelable {
         return mBundleName;
     }
 
-    @Nullable public String getApiKey() {
-        return mApiKey;
-    }
-
-    @Nullable public String getApiEmail() {
-        return mApiEmail;
-    }
-
     /* Parcelable */
 
     SessionSnapshot(Parcel in) {
@@ -129,8 +116,6 @@ public class SessionSnapshot implements Parcelable {
         mBundleVersion = in.readString();
         mBundleIdentifier = in.readString();
         mBundleName = in.readString();
-        mApiKey = in.readString();
-        mApiEmail = in.readString();
     }
 
     @Override
@@ -144,8 +129,6 @@ public class SessionSnapshot implements Parcelable {
         dest.writeString(mBundleVersion);
         dest.writeString(mBundleIdentifier);
         dest.writeString(mBundleName);
-        dest.writeString(mApiKey);
-        dest.writeString(mApiEmail);
     }
 
     @Override


### PR DESCRIPTION
This abstracts away the details of which identity method is used to identify the API user. 

With this in place, the `Client` no longer needs to handle multiple variables for one application, which means less code to maintain which hopefully means, less potential for bugs.