### PR TITLE
Issue #32 solved

### DIFF
--- a/src/main/java/com/buglife/sdk/ScreenshotAnnotatorActivity.java
+++ b/src/main/java/com/buglife/sdk/ScreenshotAnnotatorActivity.java
@@ -174,7 +174,7 @@ public class ScreenshotAnnotatorActivity extends AppCompatActivity {
         handler.postDelayed(new Runnable() {
             @Override
             public void run() {
-                ClientEventReporter.getInstance(Buglife.getContext()).reportClientEvent("presented_reporter", mBugContext.getApiIdentity());
+                //ClientEventReporter.getInstance(Buglife.getContext()).reportClientEvent("presented_reporter", mBugContext.getApiIdentity());
             }
         }, 2000);
 


### PR DESCRIPTION
The app is crashing if before sending a Bug report if you click on the captured screenshot and try to reopen it. To avoid this crash I am doing this change.