### PR TITLE
Move summary field title to resource file (strings.xml)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,15 +24,16 @@ ext {
     PUBLISH_ARTIFACT_ID = 'buglife-android'
     PUBLISH_VERSION_CODE = 48
     PUBLISH_VERSION_NAME = '1.3.4'
+    SUPPORT_VERSION = '28.0.0'
 }
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode PUBLISH_VERSION_CODE
         versionName PUBLISH_VERSION_NAME
 
@@ -45,9 +46,9 @@ android {
 }
 
 dependencies {
-    implementation "com.android.support:appcompat-v7:27.0.2"
-    implementation "com.android.support:design:27.0.2"
-    implementation "com.android.support:support-dynamic-animation:27.0.2"
+    implementation "com.android.support:appcompat-v7:$SUPPORT_VERSION"
+    implementation "com.android.support:design:$SUPPORT_VERSION"
+    implementation "com.android.support:support-dynamic-animation:$SUPPORT_VERSION"
     api "com.android.volley:volley:1.1.1"
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.assertj:assertj-core:2.8.0'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -9,12 +9,12 @@ buildscript {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     buildToolsVersion '28.0.3'
 
      defaultConfig {
          minSdkVersion 16
-         targetSdkVersion 27
+         targetSdkVersion 28
      }
     buildTypes {
         debug {
@@ -28,8 +28,8 @@ android {
 }
 
 dependencies {
-    compile rootProject
-    compile 'com.android.support:appcompat-v7:27.0.2'
-    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
-    compile 'com.android.support:design:27.0.2'
+    implementation rootProject
+    implementation "com.android.support:appcompat-v7:$SUPPORT_VERSION"
+    implementation 'com.android.support.constraint:constraint-layout:2.0.0-alpha3'
+    implementation "com.android.support:design:$SUPPORT_VERSION"
 }

--- a/src/main/java/com/buglife/sdk/Client.java
+++ b/src/main/java/com/buglife/sdk/Client.java
@@ -198,7 +198,8 @@ final class Client implements ForegroundDetector.OnForegroundListener, Invocatio
         ArrayList<InputField> inputFields = mInputFields;
 
         if (inputFields == null || inputFields.isEmpty()) {
-            TextInputField summaryInputField = TextInputField.summaryInputField();
+            String summaryFieldTitle = mAppContext.getString(R.string.summary_field_title);
+            TextInputField summaryInputField = TextInputField.summaryInputField(summaryFieldTitle);
             inputFields = new ArrayList();
             inputFields.add(summaryInputField);
         }

--- a/src/main/java/com/buglife/sdk/TextInputField.java
+++ b/src/main/java/com/buglife/sdk/TextInputField.java
@@ -18,7 +18,6 @@
 package com.buglife.sdk;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 /**
  * Represents a single- or multi-line text input field in the Buglife bug reporter interface.
@@ -62,11 +61,12 @@ public final class TextInputField extends InputField {
      * Returns the system-provided summary field (i.e. "What happened?").
      * When there are no custom input fields configured,
      * the bug reporter UI shows the summary field by default.
+     * @param title The summary field title
      */
-    public static TextInputField summaryInputField() {
+    public static TextInputField summaryInputField(String title) {
         TextInputField summaryInputField = new TextInputField(SUMMARY_ATTRIBUTE_NAME, true);
         summaryInputField.setMultiline(true);
-        summaryInputField.setTitle("What happened?");
+        summaryInputField.setTitle(title);
         return summaryInputField;
     }
 }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -21,4 +21,5 @@
     <string name="error_serialize_report">Failed to serialize bug report!</string>
     <string name="error_process_report">There was an error processing bug report!</string>
     <string name="error_save_screenshot">There was an error saving screenshot!</string>
+    <string name="summary_field_title">What happened?</string>
 </resources>


### PR DESCRIPTION
Fixes #50 
The title was hardcoded and the user was not able to override it in his app.

Bonus:
- Bump support libraries version
- Replace `compile` with `implementation`. As the warning message says, `compile` will be removed since it is obsolete and has been replaced with `implementation`. 