### PR TITLE
Fix permission errors occurring on android 8 and up when trying to store an annotated screenshot

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
     package="com.buglife.sdk">
 
     <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>

--- a/src/main/java/com/buglife/sdk/Client.java
+++ b/src/main/java/com/buglife/sdk/Client.java
@@ -23,8 +23,6 @@ import android.app.FragmentManager;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.os.Build;
 import android.os.Handler;
@@ -49,11 +47,6 @@ import java.util.List;
 
 final class Client implements ForegroundDetector.OnForegroundListener, InvocationMethodManager.OnInvocationMethodTriggeredListener {
     private static final InvocationMethod DEFAULT_INVOCATION_METHOD = InvocationMethod.SHAKE;
-    private static final String PERMISSION_INTERNET = "android.permission.INTERNET";
-    private static final String PERMISSION_WRITE_EXTERNAL_STORAGE = "android.permission.WRITE_EXTERNAL_STORAGE";
-    private static final String PERMISSION_READ_EXTERNAL_STORAGE = "android.permission.READ_EXTERNAL_STORAGE";
-    private static final String PERMISSION_SYSTEM_ALERT_WINDOW = "android.permission.SYSTEM_ALERT_WINDOW";
-    private static final String PERMISSION_ACCESS_NETWORK_STATE = "android.permission.ACCESS_NETWORK_STATE";
 
     private RetryPolicy mRetryPolicy = RetryPolicy.AUTOMATIC;
     @NonNull private final Context mAppContext;
@@ -86,13 +79,6 @@ final class Client implements ForegroundDetector.OnForegroundListener, Invocatio
         mQueuedAttachments = new ArrayList<>();
         mAttributes = new AttributeMap();
         mForegroundDetector = new ForegroundDetector(application, this);
-
-        boolean hasPermissions = checkPermissions();
-
-        if (!hasPermissions) {
-            Log.e("Android Manifest missing required permissions");
-            throw new Buglife.BuglifeException("Error starting Buglife: Your AndroidManifest.xml is missing one or more permissions");
-        }
 
         setInvocationMethod(DEFAULT_INVOCATION_METHOD);
 
@@ -304,26 +290,6 @@ final class Client implements ForegroundDetector.OnForegroundListener, Invocatio
         Client buildWithEmail(String email) {
             return new Client(mApplication, new BugReporterImpl(mApplication), new ApiIdentity.EmailAddress(email));
         }
-    }
-
-    private boolean checkPermissions() {
-        PackageInfo packageInfo;
-
-        try {
-            packageInfo = mAppContext.getPackageManager().getPackageInfo(mAppContext.getPackageName(), PackageManager.GET_PERMISSIONS);
-        } catch (PackageManager.NameNotFoundException e) {
-            Log.e("Unable to obtain package info", e);
-            return false;
-        }
-
-        List<? extends String> requestedPermissions = Arrays.asList(packageInfo.requestedPermissions);
-        List requiredPermissions;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            requiredPermissions = Arrays.asList(PERMISSION_INTERNET, PERMISSION_READ_EXTERNAL_STORAGE, PERMISSION_SYSTEM_ALERT_WINDOW, PERMISSION_ACCESS_NETWORK_STATE);
-        } else {
-            requiredPermissions = Arrays.asList(PERMISSION_INTERNET, PERMISSION_WRITE_EXTERNAL_STORAGE, PERMISSION_READ_EXTERNAL_STORAGE, PERMISSION_SYSTEM_ALERT_WINDOW, PERMISSION_ACCESS_NETWORK_STATE);
-        }
-        return requestedPermissions.containsAll(requiredPermissions);
     }
 
     private void onScreenshotTaken(FileAttachment attachment) {

--- a/src/main/java/com/buglife/sdk/PermissionHelper.java
+++ b/src/main/java/com/buglife/sdk/PermissionHelper.java
@@ -80,7 +80,7 @@ public final class PermissionHelper extends Fragment {
             return;
         }
 
-        String[] permissions = {Manifest.permission.READ_EXTERNAL_STORAGE};
+        String[] permissions = {Manifest.permission.WRITE_EXTERNAL_STORAGE};
 
         if (ActivityUtils.arePermissionsGranted(activity, permissions)) {
             mCallback.onPermissionGranted();


### PR DESCRIPTION
I explained my changes in the commit messages. Below are some additional quotes from the docs to back it up. Feel free to open discussion, criticize/revert any changes, etc. It's your sdk after all.

> **READ_EXTERNAL_STORAGE**
> Added in API level 16
> 
> Allows an application to read from external storage.
> 
> Any app that declares the WRITE_EXTERNAL_STORAGE permission is implicitly granted this permission.

From [READ_EXTERNAL_STORAGE](https://developer.android.com/reference/android/Manifest.permission.html#READ_EXTERNAL_STORAGE).

> **Permissions**
> Prior to Android 8.0 (API level 26), if an app requested a permission at runtime and the permission was granted, the system also incorrectly granted the app the rest of the permissions that belonged to the same permission group, and that were registered in the manifest.
> 
> For apps targeting Android 8.0, this behavior has been corrected. The app is granted only the permissions it has explicitly requested. However, once the user grants a permission to the app, all subsequent requests for permissions in that permission group are automatically granted.
> 
> For example, suppose an app lists both READ_EXTERNAL_STORAGE and WRITE_EXTERNAL_STORAGE in its manifest. The app requests READ_EXTERNAL_STORAGE and the user grants it. If the app targets API level 25 or lower, the system also grants WRITE_EXTERNAL_STORAGE at the same time, because it belongs to the same STORAGE permission group and is also registered in the manifest. If the app targets Android 8.0 (API level 26), the system grants only READ_EXTERNAL_STORAGE at that time; however, if the app later requests WRITE_EXTERNAL_STORAGE, the system immediately grants that privilege without prompting the user.

From [Android 8.0 Behavior Changes](https://developer.android.com/about/versions/oreo/android-8.0-changes#rmp).