### PR TITLE
Call `canDrawOverlays` again to check if overlay permission has been granted

### DIFF
--- a/src/main/java/com/buglife/sdk/screenrecorder/ScreenRecordingPermissionHelper.java
+++ b/src/main/java/com/buglife/sdk/screenrecorder/ScreenRecordingPermissionHelper.java
@@ -78,7 +78,7 @@ public final class ScreenRecordingPermissionHelper extends Fragment {
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == SCREEN_OVERLAY_REQUEST_CODE) {
-            if (resultCode == Activity.RESULT_OK) {
+            if (resultCode == Activity.RESULT_OK || Settings.canDrawOverlays(getContext())) {
                 onOverlayPermissionsGranted();
             } else {
                 mPermissionCallback.onPermissionDenied(PermissionType.OVERLAY);


### PR DESCRIPTION
Fix #65

If the `resultCode` isn't equal to `Activity.RESULT_OK`, call `Settings.canDrawOverlays` again to check whether the permission has been granted or not.